### PR TITLE
Suggestions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,7 @@ Description: Image filtering functions that takes an image and converts it to
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Depends: 
-    EBImage,
+Depends:
     magick
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,8 +2,5 @@
 
 export(image_cutoff)
 export(image_grey)
-importFrom(EBImage,channel)
-importFrom(EBImage,readImage)
-importFrom(EBImage,writeImage)
 importFrom(magick,image_read)
 importFrom(magick,image_write)

--- a/R/image_cutoff.R
+++ b/R/image_cutoff.R
@@ -11,10 +11,16 @@
 #'
 #' @importFrom magick image_read
 #' @importFrom magick image_write
-#'
+#' 
 #' @examples
-#' image_cutoff("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKwyTL9drJIaBbGx_-p8ogSLh_9DcPVDM8mQ&s","test.jpg")
-#'
+#' \donttest{
+#' tmp <- tempfile(fileext = ".jpg")
+#' image_cutoff(
+#'   "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKwyTL9drJIaBbGx_-p8ogSLh_9DcPVDM8mQ&s",
+#'   tmp
+#' )
+#' }
+#' 
 #' @export
 image_cutoff <- function (x,y) {
   pic<-image_read(x) # Read image

--- a/R/image_cutoff.R
+++ b/R/image_cutoff.R
@@ -17,32 +17,44 @@
 #'
 #' @export
 image_cutoff <- function (x,y) {
-  pic<-image_read(x)
-  bitmap<-pic[[1]]
-  bitmap_cutoff<-bitmap
-  for (i in 1:length(bitmap)) {
-
-    if (i %% 3 == 1){
+  pic<-image_read(x) # Read image
+  bitmap<-pic[[1]] # Extract bitmap
+  # Review notes: Removed the bitmap_cutoff, we can apply changes directly to bitmap.
+  # Added the below so we can handle images with rgba (derived from edit in image_grey)
+  dims<-dim(bitmap)
+  if (dims[1] == 4) {
+    a<-bitmap[4,,,drop = F] # Extract alpha channel
+    bitmap<-bitmap[1:3,,] # Extract
+  }
+  # Iterate over bitmap
+  # Review notes: Changed this to seq by 3 to remove if else.
+  for (i in seq(1, length(bitmap), by = 3)) {
       greyscale<-strtoi(bitmap[i],16)*0.299+strtoi(bitmap[i+1],16)*0.587+strtoi(bitmap[i+2],16)*0.114
+      # Apply cut-off
+      # Review notes: One might consider adding an argument to define the cutoff)
       if (greyscale < 128) {
-        bitmap_cutoff[i] <- as.raw("00")
-        bitmap_cutoff[i+1] <- as.raw("00")
-        bitmap_cutoff[i+2] <- as.raw("00")
+        bitmap[i] <- as.raw(0)
+        bitmap[i+1] <- as.raw(0)
+        bitmap[i+2] <- as.raw(0)
       }
       else {
-        bitmap_cutoff[i] <- as.raw("255")
-        bitmap_cutoff[i+1] <- as.raw("00")
-        bitmap_cutoff[i+2] <- as.raw("255")
+        bitmap[i] <- as.raw(255)
+        bitmap[i+1] <- as.raw(0)
+        bitmap[i+2] <- as.raw(255)
       }
-
-    }
-
-    else {
-      i = i+1
-    }
   }
-  output <- image_read(bitmap_cutoff)
+  # Apply alpha channel back if 4 channel input
+  if (dims[1] == 4) {
+    out <- array(as.raw(0), dim = dims)
+    out[1:3,,] <- bitmap
+    out[4,,] <- a
+    bitmap <- out
+  }
+  # Read image from bitmap
+  output <- image_read(bitmap)
+  # Save image
   image_write(output, y)
+  # Return image
   return(output)
 }
 

--- a/R/image_grey.R
+++ b/R/image_grey.R
@@ -11,8 +11,11 @@
 #' @importFrom magick image_read
 #'
 #' @examples
-#' image_grey("https://jeroen.github.io/images/frink.png","test.jpg")
-#'
+#' \donttest{
+#' tmp <- tempfile(fileext = ".jpg")
+#' image_grey("https://jeroen.github.io/images/frink.png",tmp)
+#' }
+#' 
 #' @export
 image_grey <- function (x,y) {
   # Review notes:

--- a/R/image_grey.R
+++ b/R/image_grey.R
@@ -9,19 +9,52 @@
 #' @return grey figures
 #'
 #' @importFrom magick image_read
-#' @importFrom EBImage readImage
-#' @importFrom EBImage writeImage
-#' @importFrom EBImage channel
 #'
 #' @examples
 #' image_grey("https://jeroen.github.io/images/frink.png","test.jpg")
 #'
 #' @export
 image_grey <- function (x,y) {
-  image_data <- readImage(x)
-  new_image <- channel(image_data, "green")*0.587 + channel(image_data, "blue")*0.114 + channel(image_data, "red")*0.299
+  # Review notes:
+  # I choose to use your logic from the cutoff function instead of
+  # relying on the functions from EBImage since you already had created
+  # a function for generating grayscale values and modifying the bitmap
+  # image.
+  pic<-magick::image_read(x) # Read image
+  bitmap<-pic[[1]] # Extract bitmap
+  # Review notes:
+  # This was tricky, test image was transparent png with alpha channel.
+  # So we need to remove the alpha channel to use the same approach.
+  # Option would be to vectorize over bitmap[1,,], bitmap[2,,] and, bitmap[3,,]
+  # Check number of channels
+  dims<-dim(bitmap)
+  if (dims[1] == 4) {
+    a<-bitmap[4,,,drop = F] # Extract alpha channel
+    bitmap<-bitmap[1:3,,] # Extract
+  }
+  # Review notes: Removed the bitmap_cutoff, we can apply changes directly to bitmap.
+  # Iterate over bitmap
+  # Review notes: Changed this to seq by 3 to remove if else.
+  for (i in seq(1, length(bitmap), by = 3)) {
+      # Calculate grayscale value
+      greyscale <- strtoi(bitmap[i],16)*0.299+strtoi(bitmap[i+1],16)*0.587+strtoi(bitmap[i+2],16)*0.114
+      # Apply to all channels
+      bitmap[i] <- as.raw(greyscale)
+      bitmap[i+1] <- as.raw(greyscale)
+      bitmap[i+2] <- as.raw(greyscale)
+  }
+  # Apply alpha channel back if 4 channel input
+  if (dims[1] == 4) {
+    out <- array(as.raw(0), dim = dims)
+    out[1:3,,] <- bitmap
+    out[4,,] <- a
+    bitmap <- out
+  }
 
-  writeImage(new_image, y)
-  return(image_read(new_image))
+  # Read image from bitmap
+  output <- magick::image_read(bitmap)
+  # Save file
+  magick::image_write(output, y)
+  # Return image
+  return(output)
 }
-

--- a/man/image_cutoff.Rd
+++ b/man/image_cutoff.Rd
@@ -19,6 +19,12 @@ Takes a rgb image and applies a cut-off filter where pixels with #808080 gets
 colored pink #FF00FF and other pixels #000000.
 }
 \examples{
-image_cutoff("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKwyTL9drJIaBbGx_-p8ogSLh_9DcPVDM8mQ&s","test.jpg")
+\donttest{
+tmp <- tempfile(fileext = ".jpg")
+image_cutoff(
+  "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKwyTL9drJIaBbGx_-p8ogSLh_9DcPVDM8mQ&s",
+  tmp
+)
+}
 
 }

--- a/man/image_grey.Rd
+++ b/man/image_grey.Rd
@@ -18,6 +18,9 @@ grey figures
 Takes a rgb image and converts it to grayscale.
 }
 \examples{
-image_grey("https://jeroen.github.io/images/frink.png","test.jpg")
+\donttest{
+tmp <- tempfile(fileext = ".jpg")
+image_grey("https://jeroen.github.io/images/frink.png",tmp)
+}
 
 }


### PR DESCRIPTION
Here are some additional suggestions. Removed the dependency om EBImage in the `image_gray()` function and instead used the same logic as you did in the cut-off function. Added slight manipulation to handle files with alpha channel (RGBA, as your example file for the grayscale function). Updated tests so they use tempfile for output to pass R CMD check.